### PR TITLE
osx版でアップデート系メニューが表示されない事象への対処

### DIFF
--- a/def/menu_darwin.cson
+++ b/def/menu_darwin.cson
@@ -6,8 +6,14 @@ Menu:
         value: "Atom について"
       "View License":
         value: "ライセンスを表示"
+      "Restart and Install Update":
+        value: "Restart and Install Update"
       "Check for Update":
-        value: "アップデートを確認"
+        value: "Check for Update"
+      "Checking for Update":
+        value: "Checking for Update"
+      "Downloading Update":
+        value: "Downloading Update"
       "Preferences…":
         value: "環境設定..."
       "Config…":


### PR DESCRIPTION
'Update'関連サブメニュー項目追加と英語化

アップデート系メニューはメニューの文字列が全部一致した時のみ表示される作りになっ
ている。そのため日本語化をすると表示されなくなる。

https://github.com/atom/atom/blob/master/src/browser/application-menu.coffee
showUpdateMenuItemメソッド参照
### before

![before](https://cloud.githubusercontent.com/assets/3437778/15005168/cf44694c-11fb-11e6-9f9e-cc3a406073fc.png)
### after

![check](https://cloud.githubusercontent.com/assets/3437778/15005171/d6e6aa16-11fb-11e6-8ae2-d2cbf2c0628e.png)
![checking](https://cloud.githubusercontent.com/assets/3437778/15005174/daac036c-11fb-11e6-9366-582188422509.png)
