### PR TITLE
Localization not working when preferences page is opened for a second time

### DIFF
--- a/lib/preferences.coffee
+++ b/lib/preferences.coffee
@@ -40,6 +40,15 @@ class Preferences
         btn.addEventListener('click', applyInstallPanelOnSwitch)
 
       window.JapaneseMenu.pref.done = true
+      
+      # Restore the flag when the settings panel is closed
+      editorPane = atom.workspace.getActivePane()
+      if editorPane
+        handler = editorPane.onDidRemoveItem (event) =>
+          if event.item.uri == 'atom://config'
+            window.JapaneseMenu.pref.done = false
+          handler.dispose()
+
     catch e
       console.error "日本語化に失敗しました。", e
 


### PR DESCRIPTION
便利なパッケージの提供ありがとうございます
環境設定画面について2回目以降開いた際に日本語化が働かなくなっている現象がありましたので  
ご報告します。再現手順は以下の通りです
1. 環境設定画面を開く => 日本語化される
2. 環境設定画面のタブを閉じる
3. 環境設定画面を再度開く => 日本語化 されない

Windows10とLinuxMint上でそれぞれ確認できたので、幅広い環境で発生するものと思います

設定ページの日本語化が完了すると、window.JapaneseMenu.pref.doneというフラグが立つようなのですが、
設定ページを閉じて再度開いたときにこのフラグが立ったままで日本語化処理がキャンセルされてしまうようです。
ページを閉じる際のイベントを拾ってフラグを下してやる処理を追加してみました。

#初プルリクなので怪しいところがあったらごめんなさい